### PR TITLE
Refactor transition selection in survey

### DIFF
--- a/src/mvam-bot/surveys/flow.cr
+++ b/src/mvam-bot/surveys/flow.cr
@@ -63,6 +63,20 @@ module MvamBot
         say: { type: String, nilable: true }
       })
 
+      def kind
+        if message
+          :message
+        elsif intent
+          :intent
+        elsif entity
+          :entity
+        elsif photo
+          :photo
+        elsif default
+          :default
+        end
+      end
+
     end
 
   end


### PR DESCRIPTION
Small refactor to make the order in which transitions are tested based on how they were defined in the YML file.
